### PR TITLE
Release resources before throwing/returning, do not dynamically allocate memory when not necessary

### DIFF
--- a/Source/APIProceed.cpp
+++ b/Source/APIProceed.cpp
@@ -347,8 +347,10 @@ configor::json API_PROCEED::UploadTestCase(std::string PID, std::string Data) {
     std::string ZipFilename = "/tmp/" + PID + ".zip";
     FILE *FilePointer = fopen(ZipFilename.c_str(), "w");
     if (FilePointer == NULL) throw EXCEPTION("Can not open zip file");
-    if (fwrite(Result.c_str(), 1, Result.size(), FilePointer) != Result.size())
+    if (fwrite(Result.c_str(), 1, Result.size(), FilePointer) != Result.size()) {
+        fclose(FilePointer);
         throw EXCEPTION("Can not write to zip file");
+    }
     fclose(FilePointer);
 
     std::string JudgeUsername;
@@ -392,11 +394,16 @@ configor::json API_PROCEED::UploadTestCase(std::string PID, std::string Data) {
         }
         std::string FullFilePath = IODataDir + "/" + Filename;
         FILE *FilePointer = fopen(FullFilePath.c_str(), "w");
-        if (FilePointer == NULL)
+        if (FilePointer == NULL) {
+            fclose(FilePointer);
+            unzClose(ZipFile);
+            delete[] FileDataBuffer;
             throw EXCEPTION("Can not open output file " + FullFilePath);
+        }
         if (fwrite(FileDataBuffer, 1, FileInfo.uncompressed_size, FilePointer) != FileInfo.uncompressed_size) {
             fclose(FilePointer);
             unzClose(ZipFile);
+            delete[] FileDataBuffer;
             throw EXCEPTION("Can not write to file " + FullFilePath);
         }
         delete[] FileDataBuffer;
@@ -406,6 +413,7 @@ configor::json API_PROCEED::UploadTestCase(std::string PID, std::string Data) {
         if (ZipStatus == UNZ_END_OF_LIST_OF_FILE) {
             break;
         } else if (ZipStatus != UNZ_OK) {
+            unzClose(ZipFile);
             throw EXCEPTION("Can not read zip file " + ZipFilename);
         }
     }

--- a/Source/APIProceed.cpp
+++ b/Source/APIProceed.cpp
@@ -395,7 +395,6 @@ configor::json API_PROCEED::UploadTestCase(std::string PID, std::string Data) {
         std::string FullFilePath = IODataDir + "/" + Filename;
         FILE *FilePointer = fopen(FullFilePath.c_str(), "w");
         if (FilePointer == NULL) {
-            fclose(FilePointer);
             unzClose(ZipFile);
             delete[] FileDataBuffer;
             throw EXCEPTION("Can not open output file " + FullFilePath);

--- a/Source/JudgingList.cpp
+++ b/Source/JudgingList.cpp
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <unistd.h>
 
 void JUDGING_LIST::Init() {
-    new std::thread(
+    std::thread(
         [this]() {
             while (true) {
                 while (JudgingList.empty())
@@ -35,7 +35,7 @@ void JUDGING_LIST::Init() {
                 JudgingList.pop();
                 Submission.Judge();
             }
-        });
+        }).detach();
 }
 
 void JUDGING_LIST::Add(SUBMISSION &Submission) {

--- a/Source/Socket.cpp
+++ b/Source/Socket.cpp
@@ -105,11 +105,11 @@ SOCKET::SOCKET(CALL_BACK CallBack) {
         int ClientSocket = accept(ListenSocket, (struct sockaddr *)&ClientAddress, &ClientAddressLength);
         if (ClientSocket == -1)
             Logger.Error("Can not accept");
-        new std::thread(
+        std::thread(
             [this, ClientSocket, ClientAddress, CallBack] {
                 this->SubThread(ClientSocket, ClientAddress, CallBack);
                 close(ClientSocket);
-            });
+            }).detach();
     }
 }
 

--- a/Source/TestCase.cpp
+++ b/Source/TestCase.cpp
@@ -254,6 +254,7 @@ bool TEST_CASE::CheckMemory() {
             Memory = std::max(Memory, std::stoi(Line.substr(7, Line.find("kB") - 7)) * 1024);
             if (Memory > UnjudgedTestCase->MemoryLimit) {
                 Result = JUDGE_RESULT::MEMORY_LIMIT_EXCEEDED;
+                ProcessStatus.close();
                 return false;
             }
             break;

--- a/Source/WebDataProceed.cpp
+++ b/Source/WebDataProceed.cpp
@@ -161,12 +161,11 @@ HTTP_RESPONSE WEB_DATA_PROCEED::Proceed(HTTP_REQUEST HTTPRequest) {
     } else {
         std::string Data;
         try {
-            char RequestPathBuffer[4096];
-            if (realpath((BasicFolder + RequestPath).c_str(), RequestPathBuffer) == nullptr) {
+            if (auto RequestPathBuffer = realpath((BasicFolder + RequestPath).c_str(), nullptr)) {
+                UTILITIES::LoadFile(RequestPathBuffer, Data);
+                free(RequestPathBuffer);
+            } else
                 throw EXCEPTION("No such file: " + RequestPath);
-            }
-            std::string RequestFile = RequestPathBuffer;
-            UTILITIES::LoadFile(RequestFile, Data);
         } catch (EXCEPTION ErrorData) {
             HTTPResponse.SetCode(404);
         }

--- a/Source/WebDataProceed.cpp
+++ b/Source/WebDataProceed.cpp
@@ -161,13 +161,11 @@ HTTP_RESPONSE WEB_DATA_PROCEED::Proceed(HTTP_REQUEST HTTPRequest) {
     } else {
         std::string Data;
         try {
-            char *RequestPathBuffer = new char[4096];
+            char RequestPathBuffer[4096];
             if (realpath((BasicFolder + RequestPath).c_str(), RequestPathBuffer) == nullptr) {
-                delete[] RequestPathBuffer;
                 throw EXCEPTION("No such file: " + RequestPath);
             }
             std::string RequestFile = RequestPathBuffer;
-            delete[] RequestPathBuffer;
             UTILITIES::LoadFile(RequestFile, Data);
         } catch (EXCEPTION ErrorData) {
             HTTPResponse.SetCode(404);

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -30,7 +30,7 @@ int main() {
     srand(time(NULL));
     Settings.Init();
     JudgingList.Init();
-    new SOCKET(
+    SOCKET(
         [](std::string RequestHTTPData) -> std::string {
             WEB_DATA_PROCEED Data;
             HTTP_REQUEST HTTPRequest;


### PR DESCRIPTION
Closes #18, fixes #16